### PR TITLE
Refactor :: 홈 UI 체계 재설계 및 리팩토링

### DIFF
--- a/mohajistudio-developers-iOS/mohajistudio-developers-iOS/Presentation/Scenes/Home/ViewControllers/HomeViewController.swift
+++ b/mohajistudio-developers-iOS/mohajistudio-developers-iOS/Presentation/Scenes/Home/ViewControllers/HomeViewController.swift
@@ -20,8 +20,6 @@ class HomeViewController: UIViewController {
         self.viewModel = viewModel
         
         super.init(nibName: nil, bundle: nil)
-        
-        homeView.delegate = self
     }
     
     required init?(coder: NSCoder) {
@@ -31,25 +29,28 @@ class HomeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        homeView.tagCollectionView.delegate = self
-        homeView.tagCollectionView.dataSource = self
-        homeView.postTableView.delegate = self
-        homeView.postTableView.dataSource = self
+        homeView.delegate = self
+        
+        
+        
+        homeView.homeTableView.delegate = self
+        homeView.homeTableView.dataSource = self
         
         print("Tags count: \(viewModel.tags.count)")
-        print("CollectionView frame: \(homeView.tagCollectionView.frame)")
-        print("CollectionView bounds: \(homeView.tagCollectionView.bounds)")
-    }
-    
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        print("After layout - CollectionView frame: \(homeView.tagCollectionView.frame)")
-        print("After layout - CollectionView bounds: \(homeView.tagCollectionView.bounds)")
+
     }
     
 }
 
 extension HomeViewController: HomeViewDelegate {
+    
+    func didSearch(_ query: String) {
+        viewModel.filterPosts(by: query)
+    }
+    
+    func didSelectTag(_ tag: String) {
+        viewModel.filterPosts(byTag: tag)
+    }
     
     func homeViewDidTapLogin() {
         print("homeViewDidTapLogin 탭")
@@ -66,14 +67,6 @@ extension HomeViewController: HomeViewDelegate {
         
         navigationController.modalPresentationStyle = .fullScreen
         present(navigationController, animated: true)
-    }
-    
-    func homeView(_ view: HomeView, didSearch query: String) {
-        viewModel.filterPosts(by: query)
-    }
-    
-    func homeView(_ view: HomeView, didSelectTag tag: String) {
-        viewModel.filterPosts(byTag: tag)
     }
     
 }
@@ -96,7 +89,7 @@ extension HomeViewController: UICollectionViewDelegate, UICollectionViewDataSour
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let selectedTag = viewModel.tags[indexPath.item]
         print("\(selectedTag) tag tap !")
-        homeView.delegate?.homeView(homeView, didSelectTag: selectedTag)
+        homeView.delegate?.didSelectTag(selectedTag)
     }
 
 }
@@ -119,6 +112,25 @@ extension HomeViewController: UITableViewDataSource, UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
         return UITableView.automaticDimension
+    }
+    
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let tableViewHeaderView = tableView.dequeueReusableHeaderFooterView(withIdentifier: HomeTableViewHeaderView.identifier) as? HomeTableViewHeaderView else {
+            return nil
+        }
+        
+        tableViewHeaderView.tagCollectionView.delegate = self
+        tableViewHeaderView.tagCollectionView.dataSource = self
+        
+        return tableViewHeaderView
+    }
+    
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+    
+    func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
+        return 384
     }
     
 }

--- a/mohajistudio-developers-iOS/mohajistudio-developers-iOS/Presentation/Scenes/Home/Views/HomeTableViewHeaderView.swift
+++ b/mohajistudio-developers-iOS/mohajistudio-developers-iOS/Presentation/Scenes/Home/Views/HomeTableViewHeaderView.swift
@@ -1,0 +1,152 @@
+//
+//  HomeTableViewHeaderView.swift
+//  mohajistudio-developers-iOS
+//
+//  Created by 송규섭 on 2/1/25.
+//
+
+import UIKit
+
+protocol HomeTableViewHeaderViewDelegate: AnyObject {
+    func didSearch(_ query: String)
+    func didSelectTag(_ tag: String)
+}
+
+class HomeTableViewHeaderView: UITableViewHeaderFooterView {
+    
+    static let identifier = "HomeTableViewHeaderView"
+    
+    weak var delegate: HomeTableViewHeaderViewDelegate?
+
+    private let searchHeaderView = HeaderWithIconView().then {
+        $0.configure(iconName: "Search", headerTitle: "Search")
+    }
+    
+    private let searchView = UIView().then {
+        $0.backgroundColor = UIColor(named: "Bg 2")
+        $0.layer.cornerRadius = 8
+        $0.isUserInteractionEnabled = true
+    }
+    
+    private let searchBar = UISearchBar().then {
+        $0.searchBarStyle = .minimal
+        $0.backgroundColor = .clear
+        $0.searchTextField.borderStyle = .none
+        $0.searchTextField.font = UIFont(name: "Pretendard-Medium", size: 16)
+        $0.searchTextField.backgroundColor = .clear
+        $0.searchTextField.attributedPlaceholder = NSAttributedString(string: "검색어를 입력해주세요", attributes: [NSAttributedString.Key.foregroundColor : UIColor(named: "Gray 3")])
+        $0.searchTextField.leftView = nil
+        $0.searchTextField.leftViewMode = .never
+        $0.isUserInteractionEnabled = true
+    }
+    
+    private let tagHeaderView = HeaderWithIconView().then {
+        $0.configure(iconName: "Tag", headerTitle: "Tags")
+    }
+    
+    let tagCollectionView: UICollectionView = {
+        let layout = TagFlowLayout()
+        layout.minimumInteritemSpacing = 8
+        layout.minimumLineSpacing = 8
+        layout.estimatedItemSize = UICollectionViewFlowLayout.automaticSize
+        
+        let cv = UICollectionView(frame: .zero, collectionViewLayout: layout)
+        cv.register(TagCell.self, forCellWithReuseIdentifier: "TagCell")
+        cv.backgroundColor = .clear
+        cv.isScrollEnabled = false
+        cv.showsHorizontalScrollIndicator = false
+        cv.allowsMultipleSelection = true
+        
+        return cv
+    }()
+    
+    private let postHeaderView = HeaderWithIconView().then {
+        $0.configure(iconName: "File", headerTitle: "All Post")
+    }
+    
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
+        setupUI()
+        setupActions()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented.")
+    }
+    
+    private func setupUI() {
+        backgroundColor = UIColor(named: "Bg 1")
+        
+        setupHierarchy()
+        setupConstraints()
+    }
+    
+    private func setupHierarchy() {
+        contentView.addSubview(searchHeaderView)
+        contentView.addSubview(searchView)
+        searchView.addSubview(searchBar)
+        
+        contentView.addSubview(tagHeaderView)
+        contentView.addSubview(tagCollectionView)
+        contentView.addSubview(postHeaderView)  // contentView에 추가
+    }
+    
+    private func setupConstraints() {
+        
+        contentView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        searchHeaderView.snp.makeConstraints {
+            $0.leading.trailing.equalToSuperview()
+            $0.top.equalToSuperview().offset(40)
+            $0.height.equalTo(24)
+        }
+        
+        searchView.snp.makeConstraints {
+            $0.top.equalTo(searchHeaderView.snp.bottom).offset(12)
+            $0.leading.trailing.equalToSuperview()
+            $0.height.equalTo(44)
+        }
+        
+        searchBar.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        tagHeaderView.snp.makeConstraints {
+            $0.leading.trailing.equalTo(searchHeaderView)
+            $0.top.equalTo(searchBar.snp.bottom).offset(40)
+            $0.height.equalTo(24)
+        }
+        
+        tagCollectionView.snp.makeConstraints {
+            $0.leading.trailing.equalTo(searchHeaderView)
+            $0.top.equalTo(tagHeaderView.snp.bottom).offset(12)
+            $0.height.equalTo(150)
+        }
+        
+        postHeaderView.snp.makeConstraints {
+            $0.leading.trailing.equalTo(searchHeaderView)
+            $0.top.equalTo(tagCollectionView.snp.bottom).offset(28)
+            $0.height.equalTo(24)
+            $0.bottom.equalToSuperview().offset(-12)
+        }
+        
+    }
+    
+    private func setupActions() {
+        searchBar.delegate = self
+    }
+
+}
+
+extension HomeTableViewHeaderView: UISearchBarDelegate {
+    func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
+        delegate?.didSearch(searchText)
+    }
+    
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        print("searchButtonClicked")
+        searchBar.resignFirstResponder()
+    }
+}


### PR DESCRIPTION
# 🤔 배경

기존 스크롤뷰 베이스의 UI 배치일 경우 게시글의 갯수 등 게시글에 관련해 번거로움이 많았습니다. 또한 스크롤뷰 내 테이블뷰의 위치를 잡아둔 형태기 때문에 높이를 꼭 지정해줬어야 했습니다. 이 경우 게시글 렌더링 중 잘리는 현상이 일어날 수 있고 추후 인피니티 스크롤 기능을 구현하게 된다면 비효율적이겠다싶어 해당 뷰를 전체적으로 테이블뷰로 구성했습니다.

# 📃 작업 내역

- 기존 스크롤뷰 등을 구현하도록 설계되어있던 BaseView를 상속받지 않고 새로운 구조로 설계했습니다.
- 테이블뷰의 헤더와 포스트셀들의 구조를 잡고 내부 컴포넌트들에 의해 자동으로 높이를 가지도록 설정했습니다.

# ✅ 리뷰 노트

스크롤을 하게 되는 화면의 대부분을 기존엔 스크롤뷰로 구성하겠구나라는 막연한 생각으로 초기 설계를 했고 구현까지 했는데, 이는 비효율적임을 알았고 동시에 공부하며 테이블뷰는 스크롤뷰를 상속받는 것까지 알게 되었습니다. 후에 스크롤뷰의 기능을 상속을 이용해 잘 커스텀해 쓴다면 UX적으로 괜찮은 컴포넌트가 만들어지겠구나 생각했습니다.