### PR TITLE
Refactor :: 기존 타이머 서버로부터 받은 만료시간 기준 타이머로 변경 및 로그인 관련 로그 조정

### DIFF
--- a/mohajistudio-developers-iOS/mohajistudio-developers-iOS/Models/Response/RequestEmailCodeResponse.swift
+++ b/mohajistudio-developers-iOS/mohajistudio-developers-iOS/Models/Response/RequestEmailCodeResponse.swift
@@ -1,0 +1,12 @@
+//
+//  RegisterEmailVerifyCodeResponse.swift
+//  mohajistudio-developers-iOS
+//
+//  Created by 송규섭 on 2/18/25.
+//
+
+import Foundation
+
+struct RequestEmailCodeResponse: Decodable {
+    let expiredAt: String
+}

--- a/mohajistudio-developers-iOS/mohajistudio-developers-iOS/Network/APIRouter/AuthRouter.swift
+++ b/mohajistudio-developers-iOS/mohajistudio-developers-iOS/Network/APIRouter/AuthRouter.swift
@@ -32,9 +32,9 @@ extension AuthRouter: URLRequestConvertible {
         case .checkSignUpStatus:
             return "/auth/register/status"
         case .requestEmailVerification:
-            return "/auth/register/email/request"
+            return "/auth/register/email-verification/request"
         case .verifyEmailCode:
-            return "/auth/register/email/verify"
+            return "/auth/register/email-verification/verify"
         case .refreshToken:
             return "/auth/refresh"
         case .setPassword:

--- a/mohajistudio-developers-iOS/mohajistudio-developers-iOS/Network/Base/NetworkError.swift
+++ b/mohajistudio-developers-iOS/mohajistudio-developers-iOS/Network/Base/NetworkError.swift
@@ -20,6 +20,7 @@ enum NetworkError: Error {
     case passwordAlreadyExists // R0002
     
     case nicknameAlreadyExists // R0003
+    case notValidNickname // C0001
     
     case passwordNotSet // R0005
     case profileNameNotSet // R0006
@@ -46,6 +47,8 @@ enum NetworkError: Error {
             return "알 수 없는 유저입니다."
         case .passwordAlreadyExists:
             return "비밀번호를 이미 설정하셨습니다."
+        case .notValidNickname:
+            return "유효하지 않은 닉네임입니다."
         case .nicknameAlreadyExists:
             return "이미 설정된 닉네임입니다."
         case .passwordNotSet:

--- a/mohajistudio-developers-iOS/mohajistudio-developers-iOS/Presentation/Scenes/Auth/Login/ViewModels/LoginViewModel.swift
+++ b/mohajistudio-developers-iOS/mohajistudio-developers-iOS/Presentation/Scenes/Auth/Login/ViewModels/LoginViewModel.swift
@@ -37,7 +37,6 @@ extension LoginViewModel {
             throw NetworkError.unknown("이메일 입력 오류")
         }
         
-        print("email: \(email), password: \(password)")
         tokens = try await authRepository.login(email: email, password: password)
         
         if let tokens = tokens {

--- a/mohajistudio-developers-iOS/mohajistudio-developers-iOS/Presentation/Scenes/Auth/SignUp/ViewModels/SignUpViewModel.swift
+++ b/mohajistudio-developers-iOS/mohajistudio-developers-iOS/Presentation/Scenes/Auth/SignUp/ViewModels/SignUpViewModel.swift
@@ -21,11 +21,16 @@ final class SignUpViewModel {
     private(set) var currentEmail: String?
     private var tokens: AuthTokenResponse?
     
-    // Timer Properties
     private var timer: Timer?
-    private var remainingTime: Int = 300
+    private var remainingTime: Int = 0
     var onTimerUpdate: ((String) -> Void)?
     var onTimerFinished: (() -> Void)?
+    
+    private var timeString: String {
+        let minutes = remainingTime / 60
+        let seconds = remainingTime % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
     
     // MARK: - Initialization
     init(authRepository: AuthRepositoryProtocol = AuthRepository()) {
@@ -46,31 +51,75 @@ extension SignUpViewModel {
 
 // MARK: - Timer Management
 extension SignUpViewModel {
-    var timeString: String {
-        let minutes = remainingTime / 60
-        let seconds = remainingTime % 60
-        return String(format: "%02d:%02d", minutes, seconds)
-    }
-    
-    func startTimer() {
-        timer?.invalidate()
-        remainingTime = 300
-        updateTimer()
+    func startTimer(expirationDate: String) {
+        print("[VM] startTimer 호출 - exprirationDate: \(expirationDate)")
         
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+        
+        print("[VM] 날짜 파싱 시도")
+        print("파싱할 날짜: \(expirationDate)")
+        
+        var parsedDate: Date?
+        
+        // 1. ISO8601 포맷으로 시도
+        if let date = dateFormatter.date(from: expirationDate) {
+            parsedDate = date
+            print("ISO8601 방식으로 날짜 파싱 성공")
+        }
+        // 2. 실패 시 대체 포맷으로 시도
+        else {
+            print("[VM] ISO8601 파싱 실패, 백업 방식 시도")
+            let backupFormatter = DateFormatter()
+            backupFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS"
+            backupFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+            
+            if let date = backupFormatter.date(from: expirationDate) {
+                parsedDate = date
+                print("백업 방식으로 날짜 파싱 성공")
+            } else {
+                print("모든 날짜 파싱 방법 실패")
+                onTimerFinished?()
+                return
+            }
+        }
+        
+        // 남은 시간 계산
+        if let parsedDate = parsedDate {
+            let timeInterval = parsedDate.timeIntervalSinceNow
+            remainingTime = Int(ceil(timeInterval))
+        }
+        
+        print("남은 시간(초): \(remainingTime)")
+        
+        guard remainingTime > 0 else {
+            print("남은 시간이 없음")
+            onTimerFinished?()
+            return
+        }
+        
+        // 기존 타이머가 있다면 정지
+        stopTimer()
+        
+        // 타이머 시작
+        updateTimer()
         timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true, block: { [weak self] _ in
             self?.updateTimer()
         })
+        
+        // 타이머가 실행 중일 때 앱이 백그라운드로 가는 경우에도 계속 실행되도록
+        RunLoop.current.add(timer!, forMode: .common)
     }
     
     private func updateTimer() {
         if remainingTime <= 0 {
-            timer?.invalidate()
-            timer = nil
+            stopTimer()
             onTimerFinished?()
+            return
         }
         
         onTimerUpdate?(timeString)
-        print(timeString)
         remainingTime -= 1
     }
     
@@ -78,13 +127,16 @@ extension SignUpViewModel {
         timer?.invalidate()
         timer = nil
     }
+    
+    func requestEmailVerification(email: String) async throws -> RequestEmailCodeResponse {
+        let response = try await authRepository.requestEmailVerification(email: email)
+        print(response)
+        return response
+    }
 }
 
 // MARK: - API Calls
 extension SignUpViewModel {
-    func requestEmailVerification(email: String) async throws {
-        try await authRepository.requestEmailVerification(email: email)
-    }
     
     func verifyEmailCode(code: String) async throws {
         guard let email = currentEmail else {
@@ -106,7 +158,13 @@ extension SignUpViewModel {
     }
     
     func setNickname(nickname: String) async throws {
-        try await authRepository.setNickname(nickname: nickname)
+        let pattern = #"^(?![0-9]+$)[a-zA-Z0-9_](?:[a-zA-Z0-9_]*(?:\.[a-zA-Z0-9_]+)?){1,19}$"#
+        
+        if nickname.range(of: pattern, options: .regularExpression) != nil {
+            try await authRepository.setNickname(nickname: nickname)
+        } else {
+            throw NetworkError.notValidNickname
+        }
     }
     
     func checkSignUpStatus(email: String) async throws  {


### PR DESCRIPTION
# 🤔 배경

기존 타이머는 5분을 임의로 설정 후 그 안에서 시간이 가게 하던 방식이라 서버로부터 만료 시간을 받게 되면 해당 시간까지의 남은 시간 기준으로 타이머를 구현할 필요가 있었습니다.

# 📃 작업 내역

- 이메일 인증 요청 시 만료시간을 반환받도록 변경 및 관련 api 설정 변경
- 타이머 관련 로직 변경, 서버로부터 받은 만료 시간 기준으로 변경
- 로그인 관련 테스트를 위해 아이디, 비밀번호 입력 값을 print하던 점 제거

# ✅ 리뷰 노트

비동기 작업인만큼 기다렸다가 응답을 받은 시점으로부터 로직을 실행해야 했는데, 이때 화면이 넘어가는 데에 애니메이션을 걸어두어 서브뷰로 추가되기 이전에 바로 다음 줄 코드인 타이머 시작 코드에서 해당 뷰를 찾지 못하는 현상이 있었습니다. 정말 짧은 시간 사이에도 뷰가 올라가고 찾아지는지에 여부가 갈리는구나 깨달은 중요한 순간이었습니다.